### PR TITLE
A major rewrite to the config system.

### DIFF
--- a/adispeak.sln
+++ b/adispeak.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2003
+VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "adispeak", "adispeak\adispeak.csproj", "{58EAE5D0-C633-424F-B453-3B23CC9B1516}"
 EndProject

--- a/adispeak/Adispeak.cs
+++ b/adispeak/Adispeak.cs
@@ -1366,6 +1366,7 @@ namespace adispeak
 
         private void OnWindowFocusChanged(WindowFocusArgs argument)
         {
+            Tolk.Output($"Entering {argument.Window.Name}.");
             if (!config.ContainsWindow(argument.Window.Name))
             {
                 config.AddWindow(argument.Window.Name);

--- a/adispeak/Adispeak.cs
+++ b/adispeak/Adispeak.cs
@@ -1358,7 +1358,6 @@ namespace adispeak
 
         private void OnWindowOpened(WindowOpenArgs argument)
         {
-            Tolk.Output($"Window opened: {argument.Window.Name}.");
             if (!config.ContainsWindow(argument.Window.Name))
             {
                 config.AddWindow(argument.Window.Name);
@@ -1367,11 +1366,8 @@ namespace adispeak
 
         private void OnWindowFocusChanged(WindowFocusArgs argument)
         {
-            Tolk.Output($"entering {argument.Window.Name}");
-
             if (!config.ContainsWindow(argument.Window.Name))
             {
-                Tolk.Output($"Creating settings for {argument.Window.Name}.");
                 config.AddWindow(argument.Window.Name);
             }
 

--- a/adispeak/Config.cs
+++ b/adispeak/Config.cs
@@ -101,25 +101,24 @@ namespace adispeak
 
         public bool GetWindow(string windowName, string setting)
         {
-            if (Settings.ContainsKey(windowName))
+            if (Settings.ContainsKey(windowName) && Settings[windowName].ContainsKey(setting))
             {
                 return Settings[windowName][setting];
             }
             else
             {
-                return true;
+                return Settings["global"][setting];
             }
         }
 
         public void SetWindow(string windowName, string setting, bool value)
         {
-            Settings[windowName][setting] = value;
+                Settings[windowName][setting] = value;
         }
 
         public void AddWindow(string windowName)
         {
-            Settings[windowName] = new Dictionary<string, bool>(Settings["global"]);
-            Settings[windowName].Remove("sapi");
+            Settings[windowName] = new Dictionary<string, bool>();
         }
 
         public bool ContainsWindow(string windowName)

--- a/adispeak/Config.cs
+++ b/adispeak/Config.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace adispeak
+{
+    class Config
+    {
+        private Dictionary<string, Dictionary<string, bool>> Settings = new Dictionary<string, Dictionary<string, bool>>
+        {
+            {"global", new Dictionary<string, bool>
+            {
+            {"speech", true},
+                {"sapi", false},
+            {"OnChannelActionMessage", true},
+            {"OnChannelCtcpMessage", true},
+            {"OnChannelCtcpReplyMessage", true},
+            {"OnChannelInvite", true},
+            {"OnChannelJoin", true},
+            {"OnChannelKick", true},
+            {"OnChannelModeListBan", true},
+            {"OnChannelModeListBanExempt", true},
+            {"OnChannelModeListBanUnexempt", true},
+            {"OnChannelModeListInviteExempt", true},
+            {"OnChannelModeListInviteUnexempt", true},
+            {"OnChannelModeListQuiet", true},
+            {"OnChannelModeListUnban", true},
+            {"OnChannelModeListUnquiet", true},
+            {"OnChannelModeUserAdmined", true},
+            {"OnChannelModeUserDeadmined", true},
+            {"OnChannelModeUserDehalfOpped", true},
+            {"OnChannelModeUserDeopped", true},
+            {"OnChannelModeUserDeownered", true},
+            {"OnChannelModeUserDevoiced", true},
+            {"OnChannelModeUserHalfOpped", true},
+            {"OnChannelModeUserOpped", true},
+            {"OnChannelModeUserOwnered", true},
+            {"OnChannelModeUserVoiced", true},
+            {"OnChannelNormalMessage", true},
+            {"OnChannelNoticeMessage", true},
+            {"OnChannelPart", true},
+            {"OnChannelServerModeListBan", true},
+            {"OnChannelServerModeListBanExempt", true},
+            {"OnChannelServerModeListBanUnexempt", true},
+            {"OnChannelServerModeListInviteExempt", true},
+            {"OnChannelServerModeListInviteUnexempt", true},
+            {"OnChannelServerModeListQuiet", true},
+            {"OnChannelServerModeListUnban", true},
+            {"OnChannelServerModeListUnquiet", true},
+            {"OnChannelServerModeUserAdmined", true},
+            {"OnChannelServerModeUserDeadmined", true},
+            {"OnChannelServerModeUserDehalfOpped", true},
+            {"OnChannelServerModeUserDeopped", true},
+            {"OnChannelServerModeUserDeownered", true},
+            {"OnChannelServerModeUserDevoiced", true},
+            {"OnChannelServerModeUserHalfOpped", true},
+            {"OnChannelServerModeUserOpped", true},
+            {"OnChannelServerModeUserOwnered", true},
+            {"OnChannelServerModeUserVoiced", true},
+            {"OnChannelTopic", true},
+            {"OnConnect", true},
+            {"OnConnectFailure", true},
+            {"OnConnectionLogonSuccess", true},
+            {"OnDisconnect", true},
+            {"OnMessageSent", true},
+            {"OnNick", true},
+            {"OnNotifyUserOffline", true},
+            {"OnNotifyUserOnline", true},
+            {"OnPrivateActionMessage", true},
+            {"OnPrivateCtcpMessage", true},
+            {"OnPrivateNormalMessage", true},
+            {"OnPrivateNoticeMessage", true},
+            {"OnQuit", true},
+            {"OnServerErrorMessage", true},
+            {"OnServerNoticeMessage", true},
+            {"OnUserInvitedToChannel", true},
+            {"OnUserMode", true}
+            }
+            }
+        };
+
+        public bool UseSapi
+        {
+            get => Settings["global"]["sapi"];
+            set => Settings["global"]["sapi"] = value;
+        }
+
+        public bool GetGlobal(string setting)
+        {
+            return Settings["global"][setting];
+        }
+
+        public void SetGlobal(string setting, bool value)
+        {
+            Settings["global"][setting] = value;
+        }
+
+        public bool GetWindow(string windowName, string setting)
+        {
+            if (Settings.ContainsKey(windowName))
+            {
+                return Settings[windowName][setting];
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        public void SetWindow(string windowName, string setting, bool value)
+        {
+            Settings[windowName][setting] = value;
+        }
+
+        public void AddWindow(string windowName)
+        {
+            Settings[windowName] = new Dictionary<string, bool>(Settings["global"]);
+            Settings[windowName].Remove("sapi");
+        }
+
+        public bool ContainsWindow(string windowName)
+        {
+            return Settings.ContainsKey(windowName);
+        }
+
+        public void Read(string filename)
+        {
+            if (File.Exists(filename))
+            {
+                JsonSerializer serializer = new JsonSerializer();
+                StreamReader sr = new StreamReader(filename);
+                JsonTextReader reader = new JsonTextReader(sr);
+                Settings = serializer.Deserialize<Dictionary<string, Dictionary<string, bool>>>(reader);
+                reader.Close();
+                sr.Close();
+            }
+        }
+
+            public void Write(string filename)
+            {
+                JsonSerializer serializer = new JsonSerializer();
+            serializer.Formatting = Formatting.Indented;
+                using (StreamWriter sw = new StreamWriter(filename))
+                using (JsonTextWriter writer = new JsonTextWriter(sw))
+                {
+                    serializer.Serialize(writer, Settings);
+                }
+            }
+        }
+    }

--- a/adispeak/adispeak.csproj
+++ b/adispeak/adispeak.csproj
@@ -51,8 +51,8 @@
     <Reference Include="AdiIRCAPIv2">
       <HintPath>.\bin\x64\Release\AdiIRCAPIv2.dll</HintPath>
     </Reference>
-    <Reference Include="INIFileParser, Version=2.5.2.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
-      <HintPath>..\packages\ini-parser.2.5.2\lib\net20\INIFileParser.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Adispeak.cs" />
+    <Compile Include="Config.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/adispeak/packages.config
+++ b/adispeak/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ini-parser" version="2.5.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
We now use a dictionary of dictionaries internally and store the settings using JSON.

For the end user, this now means including Newtonsoft.json.dll and Newtonsoft.json.xml in the adiIrc package. These can be found in the bin\debug folder of the project.
The plugin now creates a speech.json file on it's first run, using defaults now stored in config.cs. Either when the plugin unloads, or when /savespeech is called.

The rewrite also means we can now bring back the ability to turn on and off server messages for each server. Just toggle speech from the server window for the one you wish to change.

Also note a few code changes for manipulating settings.
To get a global setting, use config.GetGlobal(string setting).
For a window setting, config.GetWindow(string windowName, string setting).
To change settings, use config.SetGlobal and config.SetWindow, which take an additional bool parameter to set the value, along with the parameters as above.