### PR TITLE
Ouch! Hopefully found and fixed a pretty severe bug where we assumed …

### DIFF
--- a/adispeak/Adispeak.cs
+++ b/adispeak/Adispeak.cs
@@ -1309,7 +1309,7 @@ namespace adispeak
             if (config.GetGlobal("speech") && config.GetGlobal(MethodBase.GetCurrentMethod().Name)
                 && config.GetWindow(argument.Server.Name, "speech") && config.GetWindow(argument.Server.Name, MethodBase.GetCurrentMethod().Name))
             {
-                if (argument.Server.Name == _host.ActiveIWindow.Server.Name)
+                if (_host.ActiveIWindow.Server != null && argument.Server.Name == _host.ActiveIWindow.Server.Name)
                     {
                         Tolk.Output($"{argument.User.Nick} quit: {_tools.Strip(argument.QuitMessage)}");
                     }
@@ -1400,13 +1400,16 @@ namespace adispeak
                 config.AddWindow(argument.Window.Name);
             }
 
-            if (argument.Window.TextView.ScrollbarPos > 0 && argument.Window.TextView.ScrollbarPos < argument.Window.TextView.Lines.Count)
+            if (argument.Window.TextView != null) // Do we have a text view in this window? This should stop badness from happening if not!
             {
-                CurPos = argument.Window.TextView.ScrollbarPos;
-            }
-            else
-            {
-                CurPos = argument.Window.TextView.Lines.Count - 1;
+                if (argument.Window.TextView.ScrollbarPos > 0 && argument.Window.TextView.ScrollbarPos < argument.Window.TextView.Lines.Count)
+                {
+                    CurPos = argument.Window.TextView.ScrollbarPos;
+                }
+                else
+                {
+                    CurPos = argument.Window.TextView.Lines.Count - 1;
+                }
             }
         }
 


### PR DESCRIPTION
…we'd always have an ITextView object in an active window. This lead to an exception if moving into, for example, an undocked URL catcher.

In a similar vain, added a null object check for an IServer in an active window in the OnQuit event. Prevents exceptions in, for instance, a rawlog window. There might still be more of these cases to find!